### PR TITLE
Fix: #1 "Get Started" buttons on homepage not working

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@ header #logo>a>img {
 <a class="btn-secondary btn-large tve_evt_manager_listen tve_et_click" data-tcb-events="__TCB_EVENT_[{&quot;config&quot;:{&quot;s&quot;:&quot;youtube&quot;,&quot;p&quot;:{&quot;a&quot;:false,&quot;hrv&quot;:true,&quot;hyl&quot;:true,&quot;id&quot;:&quot;MtPw1WC9pxA&quot;,&quot;url&quot;:&quot;https://www.youtube.com/watch?v=MtPw1WC9pxA&quot;}},&quot;a&quot;:&quot;thrive_video&quot;,&quot;t&quot;:&quot;click&quot;}]_TNEVE_BCT__">
 <i class="fa fa-play-circle" aria-hidden="true"></i> Why StackStorm?
 </a>
-<a class="btn-primary btn-large tve_btnLink tve_evt_manager_listen ttfm2 tve_et_click" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;click&quot;,&quot;a&quot;:&quot;thrive_leads_2_step&quot;,&quot;config&quot;:{&quot;l_id&quot;:&quot;6485&quot;},&quot;elementType&quot;:&quot;a&quot;}]_TNEVE_BCT__">Get Started</a>
+<a class="btn-primary btn-large tve_btnLink tve_evt_manager_listen ttfm2 tve_et_click" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;click&quot;,&quot;a&quot;:&quot;thrive_leads_2_step&quot;,&quot;config&quot;:{&quot;l_id&quot;:&quot;6485&quot;},&quot;elementType&quot;:&quot;a&quot;}]_TNEVE_BCT__" href="https://docs.stackstorm.com/overview.html">Get Started</a>
 </div> <!-- btn-group -->
 </div> <!-- hero-container -->
 </div>
@@ -977,7 +977,7 @@ header #logo>a>img {
 </div> <!-- stacked-content -->
 </div> <!-- stacked-container -->
 <div class="btn-group">
-<a class="btn-primary btn-large tve_btnLink tve_evt_manager_listen ttfm2 tve_et_click" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;click&quot;,&quot;a&quot;:&quot;thrive_leads_2_step&quot;,&quot;config&quot;:{&quot;l_id&quot;:&quot;6485&quot;},&quot;elementType&quot;:&quot;a&quot;}]_TNEVE_BCT__">Get Started</a>
+<a class="btn-primary btn-large tve_btnLink tve_evt_manager_listen ttfm2 tve_et_click" data-tcb-events="__TCB_EVENT_[{&quot;t&quot;:&quot;click&quot;,&quot;a&quot;:&quot;thrive_leads_2_step&quot;,&quot;config&quot;:{&quot;l_id&quot;:&quot;6485&quot;},&quot;elementType&quot;:&quot;a&quot;}]_TNEVE_BCT__" href="https://docs.stackstorm.com/overview.html">Get Started</a>
 </div> <!-- btn-group -->
 </div> <!-- content-container -->
 <!------------------- BUSINESS APPLICATIONS ------------------->


### PR DESCRIPTION
Fixed the 2 nonfunctional`Get Started` buttons on homepage by adding `href` attributes with suggested the url `https://docs.stackstorm.com/overview.html`.
