### PR TITLE
Use version in URL and specific branch for installation script

### DIFF
--- a/packages/install.sh
+++ b/packages/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+BRANCH="v3.8"
+URL="https://raw.githubusercontent.com/StackStorm/st2-packages/$BRANCH/scripts/st2_bootstrap.sh"
+TIMEOUT=5
+
+cat <<EOF
+
+
+Warning: Outdated URL for StackStorm install script.
+
+You have used a retired URL to reach install.sh!
+
+Provide the version vX.X in the URL path to install StackStorm.
+
+   https://stackstorm.com/packages/vX.X/install.sh.
+
+
+For example, to install St2 $BRANCH the below URL is used:
+
+   bash <(curl -sSL https://stackstorm.com/packages/$BRANCH/install.sh) --user=st2admin --password=Ch@ngeMe
+
+
+This script will run the StackStorm Bootstrap script using $BRANCH after $TIMEOUT seconds.  Press CTRL-C to cancel the installation.
+
+EOF
+
+sleep $TIMEOUT
+echo "Executing $URL" "$@"
+
+bash <(curl -sSL "$URL") "$@"


### PR DESCRIPTION
This PR is part of multiple PRs to update the installation documentation and installation process to stop using an unversioned url that defaults to the development branch.

Official StackStorm documentation instructs users to use a shell script to install StackStorm as shown below:

`bash <(curl -sSL https://stackstorm.com/packages/install.sh) --user=st2admin --password=Ch@ngeMe`

This specific URL is redirected via Cloudflare to `https://raw.githubusercontent.com/StackStorm/st2-packages/master/scripts/st2_bootstrap.sh`.

**NOTE: Cloudflare's free plan is limited to 3 page redirections.  All 3 page redirections are currently used of which 1 of them is for the install script.**

`st2_bootstrap.sh` performs the following:
 1. Set the version to `v3.8` by default which is the latest table release of StackStorm at the time of writing this issue.
 2. Checks the StackStorm version format is either `vX.Y.Z` or `vX.Ydev`.
 3. Sets the username/password for the StackStorm installation.
 4. Tests the package type (rpm/deb) and determines if the Linux distribution is supported (ubuntu/redhat).
 5. Downloads and executes the actual installation script that corresponds to the Linux distribution (e.g. deb, el8, el9).

Because the install url is redirected specifically to `master` (the current development branch), any breaking changes applied to the development branch will break stable installations.  For example, this PR https://github.com/StackStorm/st2-packages/pull/752 is to remove deprecated operating systems from the installation script but it can't be merged because of the installation url doesn't include the version branch to download the installation script from.

To correct this behaviour so that the current and historical stable releases continue to function with the installation script, the installation url will be updated to include the branch name and be redirected to download the installation script.  E.g. to install St2 v3.3 vs St2 v3.8
<table>
<thead><tr><th>URL</th><th>Redirection</th></tr></thead>
<tbody>
<tr><td><pre>https://stackstorm.com/packages/v3.3/install.sh</pre></td><td><pre>https://raw.githubusercontent.com/StackStorm/st2-packages/v3.3/scripts/st2_bootstrap.sh</pre></td></tr>
<tr><td><pre>https://stackstorm.com/packages/v3.8/install.sh</pre></td><td><pre>https://raw.githubusercontent.com/StackStorm/st2-packages/v3.8/scripts/st2_bootstrap.sh</pre></td></tr>
</tbody>
</table>

To be able to replace the existing redirection to a redirection that includes the version, `packages/install.sh` is added to the stackstorm.com site so the deprecated url continues to fetch the install script from the current stable branch.